### PR TITLE
Make sure all webserver pathMappings are considered when building the

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -111,13 +111,15 @@ function _getFilePathFromWaterfall(waterfall, request) {
  */
 function _buildWaterfall(pathLookups, root) {
   var basename = path.basename(root);
-  var waterfall = _.map(pathLookups, function(pathLookup) {
-      var prefix = Object.keys(pathLookup)[0];
-      return {
+  var waterfall = [];
+  for (var i = 0; i < pathLookups.length; i++) {
+    _(Object.keys(pathLookups[i])).forEach(function(prefix) {
+      waterfall.push ({
         prefix: prefix.replace('<basename>', basename),
-        target: path.resolve(root, pathLookup[prefix]),
-      };
+        target: path.resolve(root, pathLookups[i][prefix]),
+      });
     });
+  }
 
   return waterfall;
 }


### PR DESCRIPTION
waterfall.

This is needed because the _.merge of the default WCT config with the
user-suppled options causes some of the pathMappings array to have objects
with multiple keys.

This function now really does match the one in
https://github.com/PolymerLabs/serve-waterfall
